### PR TITLE
Fix "mem* was not declared in this scope" errors

### DIFF
--- a/2D/solver.h
+++ b/2D/solver.h
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <cstring>
 #include <iostream>
 #include <numeric>
 #include <utility>

--- a/3D/solver.h
+++ b/3D/solver.h
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <cstring>
 #include <iostream>
 #include <numeric>
 #include <utility>


### PR DESCRIPTION
This PR fixes the following warnings while compiling on Ubuntu 18.04 with g++/gcc version 7.5.0

```
main.cpp:48:9: error: ‘memcpy’ was not declared in this scope
         memcpy(fluid_colors[i], colors[i], sizeof(colors[i]));
         ^~~~~~
main.cpp:48:9: note: suggested alternative: ‘wmemcpy’
         memcpy(fluid_colors[i], colors[i], sizeof(colors[i]));
         ^~~~~~
         wmemcpy
Fluid.cpp: In member function ‘void Fluid::init()’:
Fluid.cpp:20:5: error: ‘memset’ was not declared in this scope
     memset(U0_z, 0, sizeof(float) * num_cells);
     ^~~~~~
Fluid.cpp:20:5: note: suggested alternative: ‘wmemset’
     memset(U0_z, 0, sizeof(float) * num_cells);
     ^~~~~~
     wmemset
solver.cpp: In function ‘void project(float*, float*, float*, float*, float*, float*)’:
solver.cpp:193:5: error: ‘memset’ was not declared in this scope
     memset(S, 0, sizeof(float) * num_cells);
     ^~~~~~
solver.cpp:193:5: note: suggested alternative: ‘wmemset’
     memset(S, 0, sizeof(float) * num_cells);
     ^~~~~~
     wmemset
Makefile:11: recipe for target 'sim' failed
make: *** [sim] Error 1
```